### PR TITLE
fix: remove duplicate apps

### DIFF
--- a/spot
+++ b/spot
@@ -52,9 +52,7 @@ required() {
 }
 
 find_apps() {
-    for dir in {,$HOME}/Applications; do
-        mdfind 'kMDItemContentType == "com.apple.application-*"'
-    done
+    mdfind 'kMDItemContentType == "com.apple.application-*"'
 }
 
 find_attr_with_desc() {


### PR DESCRIPTION
On my machine, all the apps show up twice in the list when using `spot apps`. The probable cause is looping through both `/Applications` and `$HOME/Applications` unnecessarily (the `dir` variable is unused). And just to be sure, this new code still finds applications perfectly fine in both `/Applications` *and* `$HOME/Applications`, so I thought it right to remove the loop.